### PR TITLE
[#102927702] the title of reviews now shows up as "review of 'reviewe…

### DIFF
--- a/isiscb/isisdata/templates/isisdata/authority.html
+++ b/isiscb/isisdata/templates/isisdata/authority.html
@@ -123,7 +123,7 @@ var SUBJECT_CONTENT_TYPE = {{ source_content_type }};
     {% if citations_other %}
     <h4>Resources about {{ authority.name }}</h4>
 
-      {% for rel_citation in citations_other.all %}
+      {% for rel_citation in citations_other %}
           <p>
             {% if rel_citation.citation|get_authors %}
             {% for author in rel_citation.citation|get_authors %} {{ author.authority.name }};{% endfor %}<br>

--- a/isiscb/isisdata/templates/isisdata/citation.html
+++ b/isiscb/isisdata/templates/isisdata/citation.html
@@ -76,7 +76,7 @@ var SUBJECT_CONTENT_TYPE = {{ source_content_type }};
   <div class="col-sm-offset-3 col-md-offset-2 main col-sm-5 col-md-7">
     <div class="alert alert-info headerbox" role="alert">{{ citation.get_type_controlled_display }}</div>
 
-    <h3>{{ citation.title }}</h3>
+    <h3>{{ citation|get_title }}</h3>
 
     <p><strong>Authors & Contributors:</strong> {% for author in authors %} <a href="{% url 'authority' author.authority.id %}">{{ author.authority.name }};</a> {% endfor %}
     <p><strong>Abstract:</strong> {{ citation.abstract }}</p>
@@ -133,7 +133,7 @@ var SUBJECT_CONTENT_TYPE = {{ source_content_type }};
           {% else %}
             Author missing;
           {% endif %}
-          <a href="{% url 'citation' cc_rel.object.id %}">{{ cc_rel.object.title|default:"No title specified" }}</a></li>
+          <a href="{% url 'citation' cc_rel.object.id %}">{{ cc_rel.object|get_title }}</a></li>
       {% endfor %}
       </ul>
     {% endif %}
@@ -151,7 +151,7 @@ var SUBJECT_CONTENT_TYPE = {{ source_content_type }};
           {% else %}
             Author missing;
           {% endif %}
-          <a href="{% url 'citation' cc_rel.object.id %}">{{ cc_rel.object.title|default:"No title specified" }}</a></li>
+          <a href="{% url 'citation' cc_rel.object.id %}">{{ cc_rel.object|get_title }}</a></li>
       {% endfor %}
 
       {% if related_citations_inv_rb %}
@@ -164,7 +164,7 @@ var SUBJECT_CONTENT_TYPE = {{ source_content_type }};
             {% else %}
               Author missing;
             {% endif %}
-            <a href="{% url 'citation' cc_rel.subject.id %}">{{ cc_rel.subject.title|default:"No title specified" }}</a></li>
+            <a href="{% url 'citation' cc_rel.subject.id %}">{{ cc_rel.subject|get_title }}</a></li>
         {% endfor %}
       {% endif %}
 
@@ -184,7 +184,7 @@ var SUBJECT_CONTENT_TYPE = {{ source_content_type }};
           {% else %}
             Author missing;
           {% endif %}
-          <a href="{% url 'citation' cc_rel.object.id %}">{{ cc_rel.object.title|default:"No title specified" }}</a></li>
+          <a href="{% url 'citation' cc_rel.object.id %}">{{ cc_rel.object|get_title }}</a></li>
       {% endfor %}
       </ul>
     {% endif %}
@@ -201,7 +201,7 @@ var SUBJECT_CONTENT_TYPE = {{ source_content_type }};
           {% else %}
             Author missing;
           {% endif %}
-          <a href="{% url 'citation' cc_rel.subject.id %}">{{ cc_rel.subject.title|default:"No title specified" }}</a></li>
+          <a href="{% url 'citation' cc_rel.subject.id %}">{{ cc_rel.subject|get_title }}</a></li>
       {% endfor %}
       </ul>
     {% endif %}
@@ -219,7 +219,7 @@ var SUBJECT_CONTENT_TYPE = {{ source_content_type }};
           {% else %}
             Author missing;
           {% endif %}
-          <a href="{% url 'citation' cc_rel.object.id %}">{{ cc_rel.object.title|default:"No title specified" }}</a></li>
+          <a href="{% url 'citation' cc_rel.object.id %}">{{ cc_rel.object|get_title }}</a></li>
       {% endfor %}
       </ul>
     {% endif %}
@@ -236,7 +236,7 @@ var SUBJECT_CONTENT_TYPE = {{ source_content_type }};
           {% else %}
             Author missing;
           {% endif %}
-          <a href="{% url 'citation' cc_rel.subject.id %}">{{ cc_rel.subject.title|default:"No title specified" }}</a></li>
+          <a href="{% url 'citation' cc_rel.subject.id %}">{{ cc_rel.subject|get_title }}</a></li>
       {% endfor %}
       </ul>
     {% endif %}
@@ -254,7 +254,7 @@ var SUBJECT_CONTENT_TYPE = {{ source_content_type }};
           {% else %}
             Author missing;
           {% endif %}
-          <a href="{% url 'citation' cc_rel.object.id %}">{{ cc_rel.object.title|default:"No title specified" }}</a></li>
+          <a href="{% url 'citation' cc_rel.object.id %}">{{ cc_rel.object|get_title }}</a></li>
       {% endfor %}
       </ul>
     {% endif %}
@@ -271,7 +271,7 @@ var SUBJECT_CONTENT_TYPE = {{ source_content_type }};
           {% else %}
             Author missing;
           {% endif %}
-          <a href="{% url 'citation' cc_rel.subject.id %}">{{ cc_rel.subject.title|default:"No title specified" }}</a></li>
+          <a href="{% url 'citation' cc_rel.subject.id %}">{{ cc_rel.subject|get_title }}</a></li>
       {% endfor %}
       </ul>
     {% endif %}
@@ -289,7 +289,7 @@ var SUBJECT_CONTENT_TYPE = {{ source_content_type }};
           {% else %}
             Author missing;
           {% endif %}
-          <a href="{% url 'citation' cc_rel.object.id %}">{{ cc_rel.object.title|default:"No title specified" }}</a></li>
+          <a href="{% url 'citation' cc_rel.object.id %}">{{ cc_rel.object|get_title }}</a></li>
       {% endfor %}
       </ul>
     {% endif %}

--- a/isiscb/isisdata/templates/search/search.html
+++ b/isiscb/isisdata/templates/search/search.html
@@ -71,7 +71,7 @@
                     {% else %}
                     Author missing
                     {% endif %}
-                    <br><a href="{% url 'index' result.object.id %}">{% if result.object.title %}{{ result.object.title }}{% else %}Missing title{% endif %}</a>
+                    <br><a href="{% url 'index' result.object.id %}">{{ result.object|get_title }}</a>
 
                   {% endif %}
                   {% if result.object|to_class_name = 'Authority' %}


### PR DESCRIPTION
…d publication'"; bugfix: on authority page, other related citations didn't show up, but do now