### PR TITLE
Bug/isiscb 1119 (#499)

### DIFF
--- a/isiscb/curation/tasks.py
+++ b/isiscb/curation/tasks.py
@@ -10,6 +10,7 @@ from isisdata.filters import CitationFilter, AuthorityFilter
 from isisdata.operations import filter_queryset
 from django.contrib.auth.models import User
 import logging, iso8601
+from django.utils import timezone
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -144,7 +145,7 @@ def bulk_prepend_record_history(user_id, filter_params_raw, prepend_value, task_
     prepend_value = 'On %s, %s wrote: %s\n\n' % (now, user.username, prepend_value)
 
     queryset, _ = _get_filtered_record_queryset(filter_params_raw, user_id, type=object_type)
-    queryset.update(record_history=Concat(V(prepend_value), 'record_history'))
+    queryset.update(record_history=Concat(V(prepend_value), 'record_history'), modified_by=user_id, modified_on=timezone.now())
 
     try:
         if task_id:
@@ -181,7 +182,7 @@ def bulk_change_tracking_state(user_id, filter_params_raw, target_state, info,
 
     idents = list(queryset.values_list('id', flat=True))
     try:
-        queryset.update(tracking_state=target_state)
+        queryset.update(tracking_state=target_state, modified_by=user_id, modified_on=timezone.now())
         for ident in idents:
             if object_type == 'AUTHORITY':
                 AuthorityTracking.objects.create(authority_id=ident,

--- a/isiscb/curation/views.py
+++ b/isiscb/curation/views.py
@@ -351,7 +351,6 @@ def create_acrelation_for_authority(request, authority_id):
     elif request.method == 'POST':
         form = ACRelationForm(request.POST, prefix='acrelation')
         if form.is_valid():
-            form.instance.modified_by = request.user
             form.save()
 
             target = reverse('curation:curate_authority', args=(authority.id,)) + '?tab=acrelations'
@@ -389,7 +388,6 @@ def acrelation_for_authority(request, authority_id, acrelation_id):
     elif request.method == 'POST':
         form = ACRelationForm(request.POST, instance=acrelation, prefix='acrelation')
         if form.is_valid():
-            form.instance.modified_by = request.user
             form.save()
             target = reverse('curation:curate_authority', args=(authority.id,)) + '?tab=acrelations'
             if search_key and current_index:
@@ -430,7 +428,6 @@ def create_acrelation_for_citation(request, citation_id):
     elif request.method == 'POST':
         form = ACRelationForm(request.POST, prefix='acrelation')
         if form.is_valid():
-            form.instance.modified_by = request.user
             form.save()
             target = reverse('curation:curate_citation', args=(citation.id,)) + '?tab=acrelations'
             if search_key and current_index:
@@ -838,7 +835,6 @@ def linkeddata_for_citation(request, citation_id, linkeddata_id=None):
 
         if linkeddata_form.is_valid():
             linkeddata_form.instance.subject = citation
-            linkeddata_form.instance.modified_by = request.user
             linkeddata_form.save()
 
             target = reverse('curation:curate_citation', args=(citation.id,)) + '?tab=linkeddata'
@@ -891,7 +887,6 @@ def linkeddata_for_authority(request, authority_id, linkeddata_id=None):
 
         if linkeddata_form.is_valid():
             linkeddata_form.instance.subject = authority
-            linkeddata_form.instance.modified_by = request.user
             linkeddata_form.save()
 
             target = reverse('curation:curate_authority', args=(authority.id,)) + '?tab=linkeddata'
@@ -968,9 +963,7 @@ def attribute_for_citation(request, citation_id, attribute_id=None):
                 value_form = value_form_class(request.POST, prefix='value')
 
         if attribute_form.is_valid() and value_form and value_form.is_valid():
-
             attribute_form.instance.source = citation
-            attribute_form.instance.modified_by = request.user
             attribute_form.save()
             value_form.instance.attribute = attribute_form.instance
             value_form.save()
@@ -1148,7 +1141,6 @@ def citation(request, citation_id):
         if citation.type_controlled in [Citation.ARTICLE, Citation.BOOK, Citation.REVIEW, Citation.CHAPTER, Citation.THESIS] and hasattr(citation, 'part_details'):
             partdetails_form = PartDetailsForm(request.user, citation_id, request.POST, prefix='partdetails', instance=citation.part_details)
         if form.is_valid() and (partdetails_form is None or partdetails_form.is_valid()):
-            form.instance.modified_by = request.user
             form.save()
             if partdetails_form:
                 partdetails_form.save()
@@ -1789,7 +1781,6 @@ def authority(request, authority_id):
             if person_form:
                 person_form.save()
 
-            form.instance.modified_by = request.user
             form.save()
 
             target = reverse('curation:curate_authority', args=[authority.id,])

--- a/isiscb/isisdata/models.py
+++ b/isiscb/isisdata/models.py
@@ -578,6 +578,11 @@ class CuratedMixin(models.Model):
         else:
             self.public = False
 
+        # fixing issue with simple history where modifier is not saved
+        if hasattr(HistoricalRecords.thread, 'request'):
+            if HistoricalRecords.thread.request.user:
+                self.modified_by = HistoricalRecords.thread.request.user
+
         return super(CuratedMixin, self).save(*args, **kwargs)
 
     def save_obj(self, user, *args, **kwargs):
@@ -798,8 +803,15 @@ class Citation(ReferencedEntity, CuratedMixin):
             except HistoricalCitation.DoesNotExist:
                 pass
 
+        # fixing issue with simple history where hisotyr user is not saved
+        if not self.id:
+            if hasattr(HistoricalRecords.thread, 'request'):
+                if HistoricalRecords.thread.request.user:
+                    self.created_by_native = HistoricalRecords.thread.request.user
+
         self.title_for_sort = normalize(unidecode.unidecode(get_title(self)))
         self.title_for_display = get_display_title(self)
+
         super(Citation, self).save(*args, **kwargs)
 
     @property

--- a/isiscb/isisdata/tasks.py
+++ b/isiscb/isisdata/tasks.py
@@ -79,6 +79,7 @@ def bulk_update_citations(user_id, filter_params_raw, field, value, task_id=None
                 task.current_value = i
                 task.save()
             setattr(obj, field, value)
+            obj.modified_by_id = user_id
             obj.save()
         task.state = 'SUCCESS'
         task.save()

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ django-oauth-toolkit==0.12.0
 djangorestframework-filters==0.10.2
 django-registration==1.0
 django-simple-captcha==0.5.6
-django-simple-history==1.7.0
+django-simple-history==2.2.0
 django-storages==1.1.8
 django-storages-redux==1.3.2
 djangorestframework==3.6.1


### PR DESCRIPTION
* [ISISCB-1119] save modifier by reading from simple history middleware

* [ISISCB-1119] set modifier and date for bulk changes

* [ISISCB-119] modified_by should now consistently be updated

when an object is changed

* [ISISCB-1119] remove duplicate migration